### PR TITLE
Account for alternate names for "USA" in JGI MG/MT "country_name"

### DIFF
--- a/etl.py
+++ b/etl.py
@@ -155,6 +155,12 @@ class MetadataRetriever:
             df.loc[df["dnase_rna"] == "yes", "dnase_rna"] = 'Y'
             df.loc[df["dnase_rna"] == "no", "dnase_rna"] = 'N'
 
+        # Address standardizing "USA" country name for MG and MT
+        # Replace "country_name" with "USA" if it exists
+        usa_names = ["United States", "United States of America"]
+        if self.user_facility == 'jgi_mg' or self.user_facility == 'jgi_mt':
+            df["country_name"]= df["country_name"].replace(usa_names, "USA")
+
         return df
 
 

--- a/etl.py
+++ b/etl.py
@@ -157,7 +157,7 @@ class MetadataRetriever:
 
         # Address standardizing "USA" country name for MG and MT
         # Replace "country_name" with "USA" if it exists
-        usa_names = ["United States", "United States of America"]
+        usa_names = ["United States", "United States of America", "US", "America", "usa", "united states", "united states of america", "us", "america"]
         if self.user_facility == 'jgi_mg' or self.user_facility == 'jgi_mt':
             df["country_name"]= df["country_name"].replace(usa_names, "USA")
 


### PR DESCRIPTION
Closes #55 

- Account for "United States" and "United States of America" when naming "USA" in `country_name ` field for JGI MG and MT. 
- Replace these alternatives with "USA"