### PR TITLE
Address multiple sample types and data not being read in

### DIFF
--- a/etl.py
+++ b/etl.py
@@ -130,29 +130,45 @@ class MetadataRetriever:
                 row.at["latitude"] = values[0]
                 row.at["longitude"] = values[1]
 
-                # Update the original DataFrame with the new row values
-                # df.loc[index] = row
-
             if "depth" in df.columns:
-                # Case - different delimiters used
-                row["depth"] = row["depth"].str.replace("-", " - ")
-                # Case - only one value provided for depth (single value will be max and min)
-                # Checking if the value is a string, because if there is a dash, that will be the case
-                if type(row["depth"]) == str:
-                    row[["minimum_depth", "maximum_depth"]] = row["depth"].str.split(
-                        " - ", expand=True
-                    )
-                else:
-                    row[["minimum_depth"]] = row["depth"]
-                    row[["maximum_depth"]] = row["depth"]
-                # dfNew = row["depth"].str.split(" - ", expand=True)
-                # if dfNew.shape[0] == 1:
-                #     row[["minimum_depth"]] = dfNew[0]
-                #     row[["maximum_depth"]] = dfNew[0]
-                # else:
+                # # Case - different delimiters used
+                # row["depth"] = row["depth"].str.replace("-", " - ")
+                # # Case - only one value provided for depth (single value will be max and min)
+                # # Checking if the value is a string, because if there is a dash, that will be the case
+                # if type(row["depth"]) == str:
                 #     row[["minimum_depth", "maximum_depth"]] = row["depth"].str.split(
                 #         " - ", expand=True
                 #     )
+                # else:
+                #     row[["minimum_depth"]] = row["depth"]
+                #     row[["maximum_depth"]] = row["depth"]
+                # # dfNew = row["depth"].str.split(" - ", expand=True)
+                # # if dfNew.shape[0] == 1:
+                # #     row[["minimum_depth"]] = dfNew[0]
+                # #     row[["maximum_depth"]] = dfNew[0]
+                # # else:
+                # #     row[["minimum_depth", "maximum_depth"]] = row["depth"].str.split(
+                # #         " - ", expand=True
+                # #     )
+
+                # Case - different delimiters used
+                row["depth"] = str(row["depth"]).replace("-", " - ")
+                
+                # Case - only one value provided for depth (single value will be max and min)
+                # Checking if the value is a string, because if there is a dash, that will be the case
+                if type(row["depth"]) == str:
+                    values = row["depth"].split(" - ")
+                    # Check if only one value
+                    if len(values) == 1:
+                        row.at["minimum_depth"] = float(values[0])
+                        row.at["maximum_depth"] = float(values[0])
+                    # Check if it's a range
+                    elif len(values) == 2:
+                        row.at["minimum_depth"] = float(values[0])
+                        row.at["maximum_depth"] = float(values[1])
+                else:
+                    row.at["minimum_depth"] = row["depth"]
+                    row.at["maximum_depth"] = row["depth"]
 
         if "geo_loc_name" in df.columns:
             df["country_name"] = df["geo_loc_name"].str.split(":").str[0]

--- a/etl.py
+++ b/etl.py
@@ -89,6 +89,7 @@ class MetadataRetriever:
         sample_data_keys = [
             key for key in all_keys_data if key not in user_facility_keys
         ]
+        print(sample_data_keys)
 
         # Loop through resulting keys and combine with common_df by samp_name
         for key in sample_data_keys:
@@ -97,10 +98,13 @@ class MetadataRetriever:
                 "sampleData"
             ].get(key, {})
             sample_data_df = pd.DataFrame(sample_data)
+            # print(df)
+            # df.to_csv('SAMP_OUTPUT.csv', index=False)
 
             if not sample_data_df.empty:
                 df = pd.merge(df, sample_data_df, on="samp_name", how="left", suffixes=("", "_dup"))
-
+            # print(df)
+            # df.to_csv('SAMP_OUTPUT.csv', index=False)
             if "analysis_type_dup" in df.columns:
                 df.drop(columns=["analysis_type_dup"], inplace=True)
 
@@ -108,22 +112,47 @@ class MetadataRetriever:
             df['sample_isolated_from'] = key
 
         # Begin collecting detailed sample data
+            
+        df.to_csv('SAMP_OUTPUT.csv', index=False)
+        # Add some kind of "for sample in samples" situation 
+        for index, row in df.iterrows():
+            print(row["samp_name"])
 
-        if "lat_lon" in df.columns:
-            df[["latitude", "longitude"]] = df["lat_lon"].str.split(" ", expand=True)
+            if "lat_lon" in df.columns:
+                print(row["lat_lon"])
+                # values = str(row["lat_lon"]).split(" ")
+                # df.loc[index, ["latitude", "longitude"]] = values
+                # row["lat_lon"] = str(row["lat_lon"])
+                # row[["latitude", "longitude"]] = row["lat_lon"].str.split(" ", expand=True, n=1)
+                values = str(row["lat_lon"]).split(" ", 1)
+        
+                # Assign the split values back to the row
+                row.at["latitude"] = values[0]
+                row.at["longitude"] = values[1]
 
-        if "depth" in df.columns:
-            # Case - different delimiters used
-            df["depth"] = df["depth"].str.replace("-", " - ")
-            # Case - only one value provided for depth (single value will be max and min)
-            dfNew = df["depth"].str.split(" - ", expand=True)
-            if dfNew.shape[0] == 1:
-                df[["minimum_depth"]] = dfNew[0]
-                df[["maximum_depth"]] = dfNew[0]
-            else:
-                df[["minimum_depth", "maximum_depth"]] = df["depth"].str.split(
-                    " - ", expand=True
-                )
+                # Update the original DataFrame with the new row values
+                # df.loc[index] = row
+
+            if "depth" in df.columns:
+                # Case - different delimiters used
+                row["depth"] = row["depth"].str.replace("-", " - ")
+                # Case - only one value provided for depth (single value will be max and min)
+                # Checking if the value is a string, because if there is a dash, that will be the case
+                if type(row["depth"]) == str:
+                    row[["minimum_depth", "maximum_depth"]] = row["depth"].str.split(
+                        " - ", expand=True
+                    )
+                else:
+                    row[["minimum_depth"]] = row["depth"]
+                    row[["maximum_depth"]] = row["depth"]
+                # dfNew = row["depth"].str.split(" - ", expand=True)
+                # if dfNew.shape[0] == 1:
+                #     row[["minimum_depth"]] = dfNew[0]
+                #     row[["maximum_depth"]] = dfNew[0]
+                # else:
+                #     row[["minimum_depth", "maximum_depth"]] = row["depth"].str.split(
+                #         " - ", expand=True
+                #     )
 
         if "geo_loc_name" in df.columns:
             df["country_name"] = df["geo_loc_name"].str.split(":").str[0]
@@ -149,11 +178,13 @@ class MetadataRetriever:
         # Address 'Was sample DNAse treated?' col
         # Change from 'yes/no' to 'Y/N'
         if self.user_facility == 'jgi_mg':
-            df.loc[df["dna_dnase"] == "yes", "dna_dnase"] = 'Y'
-            df.loc[df["dna_dnase"] == "no", "dna_dnase"] = 'N'
+            if 'dna_dnase' in df.columns:
+                df.loc[df["dna_dnase"] == "yes", "dna_dnase"] = 'Y'
+                df.loc[df["dna_dnase"] == "no", "dna_dnase"] = 'N'
         if self.user_facility == 'jgi_mt':
-            df.loc[df["dnase_rna"] == "yes", "dnase_rna"] = 'Y'
-            df.loc[df["dnase_rna"] == "no", "dnase_rna"] = 'N'
+            if 'dna_dnase' in df.columns:
+                df.loc[df["dnase_rna"] == "yes", "dnase_rna"] = 'Y'
+                df.loc[df["dnase_rna"] == "no", "dnase_rna"] = 'N'
 
         return df
 

--- a/etl.py
+++ b/etl.py
@@ -89,7 +89,9 @@ class MetadataRetriever:
         sample_data_keys = [
             key for key in all_keys_data if key not in user_facility_keys
         ]
-        print(sample_data_keys)
+
+        # Create an empty list to store dataframes for each key
+        sample_data_dfs = []
 
         # Loop through resulting keys and combine with common_df by samp_name
         for key in sample_data_keys:
@@ -97,59 +99,40 @@ class MetadataRetriever:
             sample_data: Dict[str, Any] = response["metadata_submission"][
                 "sampleData"
             ].get(key, {})
-            sample_data_df = pd.DataFrame(sample_data)
-            # print(df)
-            # df.to_csv('SAMP_OUTPUT.csv', index=False)
-
-            if not sample_data_df.empty:
-                df = pd.merge(df, sample_data_df, on="samp_name", how="left", suffixes=("", "_dup"))
-            # print(df)
-            # df.to_csv('SAMP_OUTPUT.csv', index=False)
-            if "analysis_type_dup" in df.columns:
-                df.drop(columns=["analysis_type_dup"], inplace=True)
-
-            # Append the non-UF key name into the df for 'Sample Isolated From' col in jgi mg/mt
-            df['sample_isolated_from'] = key
 
         # Begin collecting detailed sample data
             
-        df.to_csv('SAMP_OUTPUT.csv', index=False)
-        # Add some kind of "for sample in samples" situation 
+            # If there's sample data, create a DataFrame and add it to the list
+            if sample_data:
+                sample_data_df = pd.DataFrame(sample_data)
+                
+                # Add the non-UF key name into the df for 'Sample Isolated From' col in jgi mg/mt
+                sample_data_df['sample_isolated_from'] = key
+                # Append to list of dfs
+                sample_data_dfs.append(sample_data_df)
+
+        # Concatenate sample dataframes into one (if they exist)
+        if sample_data_dfs:
+            all_sample_data_df = pd.concat(sample_data_dfs, ignore_index=True)
+            # Merge the combined sample data with df on samp_name
+            if not df.empty and not all_sample_data_df.empty:
+                df = pd.merge(df, all_sample_data_df, on="samp_name", how="outer")
+        
         for index, row in df.iterrows():
-            print(row["samp_name"])
 
             if "lat_lon" in df.columns:
-                print(row["lat_lon"])
-                # values = str(row["lat_lon"]).split(" ")
-                # df.loc[index, ["latitude", "longitude"]] = values
-                # row["lat_lon"] = str(row["lat_lon"])
-                # row[["latitude", "longitude"]] = row["lat_lon"].str.split(" ", expand=True, n=1)
-                values = str(row["lat_lon"]).split(" ", 1)
-        
-                # Assign the split values back to the row
-                row.at["latitude"] = values[0]
-                row.at["longitude"] = values[1]
+
+                # Check if lat_lon is nan before trying to split it
+                if pd.isnull(row["lat_lon"]):
+                    df.at[index, "latitude"] = None
+                    df.at[index, "longitude"] = None
+                else: 
+                    values = str(row["lat_lon"]).split(" ", 1)
+                    # Assign the split values back to the row
+                    df.at[index, "latitude"] = values[0]
+                    df.at[index, "longitude"] = values[1]
 
             if "depth" in df.columns:
-                # # Case - different delimiters used
-                # row["depth"] = row["depth"].str.replace("-", " - ")
-                # # Case - only one value provided for depth (single value will be max and min)
-                # # Checking if the value is a string, because if there is a dash, that will be the case
-                # if type(row["depth"]) == str:
-                #     row[["minimum_depth", "maximum_depth"]] = row["depth"].str.split(
-                #         " - ", expand=True
-                #     )
-                # else:
-                #     row[["minimum_depth"]] = row["depth"]
-                #     row[["maximum_depth"]] = row["depth"]
-                # # dfNew = row["depth"].str.split(" - ", expand=True)
-                # # if dfNew.shape[0] == 1:
-                # #     row[["minimum_depth"]] = dfNew[0]
-                # #     row[["maximum_depth"]] = dfNew[0]
-                # # else:
-                # #     row[["minimum_depth", "maximum_depth"]] = row["depth"].str.split(
-                # #         " - ", expand=True
-                # #     )
 
                 # Case - different delimiters used
                 row["depth"] = str(row["depth"]).replace("-", " - ")
@@ -160,15 +143,15 @@ class MetadataRetriever:
                     values = row["depth"].split(" - ")
                     # Check if only one value
                     if len(values) == 1:
-                        row.at["minimum_depth"] = float(values[0])
-                        row.at["maximum_depth"] = float(values[0])
+                        df.at[index, "minimum_depth"] = float(values[0])
+                        df.at[index, "maximum_depth"] = float(values[0])
                     # Check if it's a range
                     elif len(values) == 2:
-                        row.at["minimum_depth"] = float(values[0])
-                        row.at["maximum_depth"] = float(values[1])
+                        df.at[index, "minimum_depth"] = float(values[0])
+                        df.at[index, "maximum_depth"] = float(values[1])
                 else:
-                    row.at["minimum_depth"] = row["depth"]
-                    row.at["maximum_depth"] = row["depth"]
+                    df.at[index, "minimum_depth"] = row["depth"]
+                    df.at[index, "maximum_depth"] = row["depth"]
 
         if "geo_loc_name" in df.columns:
             df["country_name"] = df["geo_loc_name"].str.split(":").str[0]

--- a/input-files/jgi_mg_header.json
+++ b/input-files/jgi_mg_header.json
@@ -17,7 +17,7 @@
     },
     "Sample Name*": {
         "1": "Give the sample a name that is meaningful to you. Sample names must be unique across all JGI projects and contain ASCII characters only.",
-        "sub_port_mapping": "dna_sample_name"
+        "sub_port_mapping": "samp_name"
     },
     "Biological replicate/sample group Name* (required for RNA expression, ChIP, Bisulphite-Seq, Methylation)": {
         "1": "Samples that are biological replicates should have the same group name.  If your project does not contain biological replicates, give each sample its own group name."

--- a/input-files/jgi_mt_header.json
+++ b/input-files/jgi_mt_header.json
@@ -17,7 +17,7 @@
     },
     "Sample Name*": {
         "1": "Give the sample a name that is meaningful to you. Sample names must be unique across all JGI projects and contain ASCII characters only.",
-        "sub_port_mapping": "rna_sample_name"
+        "sub_port_mapping": "samp_name"
     },
     "Biological replicate/sample group Name* (required for RNA expression, ChIP, Bisulphite-Seq, Methylation)": {
         "1": "Samples that are biological replicates should have the same group name.  If your project does not contain biological replicates, give each sample its own group name."


### PR DESCRIPTION
This PR addresses a few different things: 

- The sample name wasn't being populated in the resulting Excel file - I updated the mapping reference for the JGI MG/MT header files to `samp_name` to ensure that the sample name makes it to the Excel file
- The latitude/longitude and max/min depth fields would raise issues with cases where there is only one value, or if no value was provided - I updated that part of `etl.py` to account for these cases, as well as issues where not every sample would get updated with these columns
- When reading in the submission data initially, there was an issue where in the dataframe, there would be duplicate columns, and some of the data would only be in those duplicated columns, so not all the data would be processed by the rest of the script - I reworked this part of `etl.py` to create a new dataframe per key, and then combine them all so that there is one resulting dataframe with no duplicate columns, so all the data should get processed by the rest of the script now. 