### PR TITLE
Add long-read keyword for etl use

### DIFF
--- a/etl.py
+++ b/etl.py
@@ -18,7 +18,8 @@ class MetadataRetriever:
     USER_FACILITY_DICT: Dict[str, str] = {
         "emsl": "emsl_data",
         "jgi_mg": "jgi_mg_data",
-        "jgi_mt": "jgi_mt_data",
+        "jgi_mg_lr": "jgi_mg_lr_data",
+        "jgi_mt": "jgi_mt_data"
     }
 
     def __init__(self, metadata_submission_id: str, user_facility: str) -> None:
@@ -85,7 +86,7 @@ class MetadataRetriever:
 
         # Find non-user-facility keys (ie, plant_associated, water, etc)
         all_keys_data = response["metadata_submission"]["sampleData"]
-        user_facility_keys = ["emsl_data", "jgi_mg_data", "jgi_mt_data"]
+        user_facility_keys = ["emsl_data", "jgi_mg_data", "jgi_mg_lr_data", "jgi_mt_data"]
         sample_data_keys = [
             key for key in all_keys_data if key not in user_facility_keys
         ]


### PR DESCRIPTION
Closes #70 

Sample usage: 
`poetry run python etl.py -s  <submission-id> -uf samp_name -u jgi_mg_lr -m input-files/jgi_mg_header.json -o output.xlsx
`